### PR TITLE
Update Readme package name and usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
-# vue-embed-gist
+# vue-embed-gist-nojquery
+Vue component to embed Github Gists using jsonp, instead of jquery.  Inspired by and forked from Blair Vanderhoof's [gist-embed](https://github.com/sudhanshu-15/vue-embed-gist).
 
-# This was forked from https://github.com/sudhanshu-15/vue-embed-gist
-
-# I literally just wanted to remove jquery.
-
-Vue component to embed Github Gists, inspired by Blair Vanderhoof's gist-embed. (https://github.com/blairvanderhoof/gist-embed)
 
 ## Install
 
 ```bash
-yarn add vue-embed-gist
+yarn add vue-embed-gist-nojquery
 ```
 or
 ```bash
-npm install --save vue-embed-gist
+npm install --save vue-embed-gist-nojquery
 ```
 
-<!-- CDN: [UNPKG](https://unpkg.com/vue-embed-gist/) | [jsDelivr](https://cdn.jsdelivr.net/npm/vue-embed-gist/) (available as `window.VueEmbedGist`) -->
+<!-- CDN: [UNPKG](https://unpkg.com/vue-embed-gist-nojquery) | [jsDelivr](https://unpkg.com/vue-embed-gist-nojquery) (available as `window.VueEmbedGist`) -->
 
 ## Usage
 
@@ -28,7 +24,7 @@ npm install --save vue-embed-gist
 </template>
 
 <script>
-import VueEmbedGist from 'vue-embed-gist'
+import VueEmbedGist from 'vue-embed-gist-nojquery'
 
 export default {
   components: {
@@ -54,4 +50,4 @@ File name in the gist
 
 ## License
 
-MIT &copy; [Sudhanshu Siddh](www.ssiddh.me)
+MIT &copy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-embed-gist",
+  "name": "vue-embed-gist-nojquery",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "vue-embed-gist",
+  "name": "vue-embed-gist-nojquery",
   "version": "1.0.1",
   "description": "Vue component to embed Github Gists, inspired by Blair Vanderhoof&#39;s gist-embed.",
   "repository": {
-    "url": "sudhanshu-15/vue-embed-gist",
+    "url": "https://github.com/matt123miller/vue-embed-gist",
     "type": "git"
   },
   "keywords": [
     "vue",
     "gist",
     "embed",
-    "component"
+    "component",
+    "github gist"
   ],
-  "main": "dist/vue-embed-gist.cjs.js",
+  "main": "dist/vue-embed-gist-nojquery.cjs.js",
   "files": [
     "dist"
   ],
@@ -40,7 +41,7 @@
       "cjs",
       "umd"
     ],
-    "name": "vue-embed-gist",
+    "name": "vue-embed-gist-nojquery",
     "plugins": [
       "vue"
     ]

--- a/src/components/VueGist.vue
+++ b/src/components/VueGist.vue
@@ -52,7 +52,3 @@ export default {
   }
 };
 </script>
-
-<style scoped>
-@import url("https://assets-cdn.github.com/assets/gist-embed-1baaff35daab552f019ad459494450f1.css");
-</style>


### PR DESCRIPTION
Update Readme to accurately demonstrate how to use this package.

Remove broken 404'd link to a github stylesheet.

Additional Suggestion: Rename this github repo to match the NPM package. `vue-embed-gist-nojquery`